### PR TITLE
Fix docs: use crates/matchy for cargo install --path

### DIFF
--- a/book/src/dev/building.md
+++ b/book/src/dev/building.md
@@ -21,7 +21,7 @@ cargo build --release
 cargo test
 
 # Install CLI
-cargo install --path .
+cargo install --path crates/matchy
 ```
 
 ## Build Profiles

--- a/book/src/getting-started/cli-installation.md
+++ b/book/src/getting-started/cli-installation.md
@@ -42,7 +42,7 @@ To install the latest development version:
 ```console
 $ git clone https://github.com/matchylabs/matchy
 $ cd matchy
-$ cargo install --path .
+$ cargo install --path crates/matchy
 ```
 
 ## Using without installation

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -79,7 +79,7 @@ cargo install matchy
 ### From source
 
 ```bash
-cargo install --path .
+cargo install --path crates/matchy
 ```
 
 Verify:


### PR DESCRIPTION
## Description
Fix documentation for installing the CLI from source. The repo root `Cargo.toml` is a workspace manifest (no `[package]`), so `cargo install --path .` fails with "found a virtual manifest ... instead of a package manifest". The docs now use `cargo install --path crates/matchy`, which installs the matchy binary from the main crate.

Updated:
- `book/src/getting-started/installation.md` – "From source" section
- `book/src/getting-started/cli-installation.md` – "Installing from source" section
- `book/src/dev/building.md` – "Quick Build" / Install CLI step

Fixes # (issue)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [x] Existing test suite passes (`cargo test`)
- [ ] Added new tests for new functionality
- [ ] Tested on multiple platforms (Linux, macOS, Windows)
- [ ] Ran benchmarks to verify performance (`cargo bench`)
- [ ] Tested C FFI integration (if applicable)

(Docs-only change; verified install command works from repo root.)

## Checklist
- [x] My code follows the style guidelines of this project (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`cargo clippy`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated CHANGELOG.md (if applicable)

## Performance Impact
N/A – documentation only.

## Breaking Changes
None.

## Additional Context
`.github/workflows/deploy-docs.yml` correctly uses `cargo install --path .` from inside `book/mdbook-project-version` (a separate package); no change there.

