### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/crates/matchy-wasm/demo/pkg/matchy_wasm.js
+++ b/crates/matchy-wasm/demo/pkg/matchy_wasm.js
@@ -184,7 +184,7 @@ if (!('encodeInto' in cachedTextEncoder)) {
             read: arg.length,
             written: buf.length
         };
-    }
+    };
 }
 
 let WASM_VECTOR_LEN = 0;


### PR DESCRIPTION
Add an explicit semicolon to terminate the function-assignment statement inside the `if (!('encodeInto' in cachedTextEncoder))` block.

Best fix (no functional change):
- In `crates/matchy-wasm/demo/pkg/matchy_wasm.js`, at the end of the assignment
  `cachedTextEncoder.encodeInto = function (arg, view) { ... }`
  change the closing `}` to `};`.
- Do not alter logic, control flow, or any other formatting outside this statement.

This preserves behavior, removes reliance on ASI, and restores consistency with the rest of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._